### PR TITLE
Fix note highlight

### DIFF
--- a/dist/dist.css
+++ b/dist/dist.css
@@ -48,7 +48,8 @@
   --sn-desktop-titlebar-ui-color: var(--foreground-color);
   --sn-desktop-titlebar-ui-hover-color: var(--highlight-color);
   --sn-stylekit-scrollbar-track-border-color: var(--border-color);
-  --sn-stylekit-scrollbar-thumb-color: var(--sn-stylekit-info-color); }
+  --sn-stylekit-scrollbar-thumb-color: var(--sn-stylekit-info-color);
+  --sn-stylekit-grey-5: var(--highlight-color); }
 
 #editor-title-bar {
   padding-top: 14px;

--- a/src/main.scss
+++ b/src/main.scss
@@ -68,6 +68,7 @@
 
   --sn-stylekit-scrollbar-track-border-color: var(--border-color);
   --sn-stylekit-scrollbar-thumb-color: var(--sn-stylekit-info-color);
+  --sn-stylekit-grey-5: var(--highlight-color);
 }
 
 #editor-title-bar {


### PR DESCRIPTION
Add `--sn-stylekit-grey-5` tag as mentioned in Standard Notes v3.9.15 changes.

Here's the result:
![fix_note_highlight](https://user-images.githubusercontent.com/16612598/151161180-464ca4a9-f93d-4dc2-9992-3c9a40ac57fb.png)
