### PR TITLE
fix(sn-theme-dracula.json): bump version to 0.0.18

### DIFF
--- a/sn-theme-dracula.json
+++ b/sn-theme-dracula.json
@@ -3,7 +3,7 @@
   "name": "Dracula",
   "content_type": "SN|Theme",
   "area": "themes",
-  "version": "0.0.16",
+  "version": "0.0.18",
   "description": "A Dracula theme for Standard Notes",
   "url": "https://cdn.jsdelivr.net/gh/dracula/standard-notes@0.0.18/dist/dist.css",
   "latest_url": "https://cdn.jsdelivr.net/gh/dracula/standard-notes/sn-theme-dracula.json",


### PR DESCRIPTION
Currently, the CDN link is still picking up version `0.0.16`.

I noticed in the `sn-theme-dracula.json` file that the version was still at `0.0.16`. I think updating this version to the latest release should fix that.

D